### PR TITLE
Hook controlled checkpoints

### DIFF
--- a/src/Firewall.sol
+++ b/src/Firewall.sol
@@ -269,9 +269,15 @@ abstract contract Firewall is IFirewall, IAttesterInfo, FirewallPermissions {
     {
         ICheckpointHook checkpointHook = _getFirewallStorage().checkpointHook;
         if (address(checkpointHook) != address(0)) {
-            HookResult result = checkpointHook.handleCheckpoint(caller, selector);
+            HookResult result;
+            if (checkpoint.activation == Activation.HookControlled) {
+                result = checkpointHook.handleCheckpointWithCallData(caller, selector, msg.data);
+            } else {
+                result = checkpointHook.handleCheckpoint(caller, selector);
+            }
             if (result == HookResult.ForceActivation) return true;
             if (result == HookResult.ForceDeactivation) return false;
+            if (result == HookResult.Block) revert CheckpointBlockedByHook();
             // Otherwise, just keep on with default checkpoint configuration and logic.
         }
         if (checkpoint.activation == Activation.Inactive) return false;

--- a/src/Firewall.sol
+++ b/src/Firewall.sol
@@ -32,6 +32,7 @@ abstract contract Firewall is IFirewall, IAttesterInfo, FirewallPermissions {
     error UntrustedAttester(address attester);
     error CheckpointBlocked();
     error RefStartLargerThanEnd();
+    error CheckpointBlockedByHook();
 
     struct FirewallStorage {
         ISecurityValidator validator;
@@ -235,9 +236,15 @@ abstract contract Firewall is IFirewall, IAttesterInfo, FirewallPermissions {
     {
         ICheckpointHook checkpointHook = _getFirewallStorage().checkpointHook;
         if (address(checkpointHook) != address(0)) {
-            HookResult result = checkpointHook.handleCheckpointWithRef(caller, selector, ref);
+            HookResult result;
+            if (checkpoint.activation == Activation.HookControlled) {
+                result = checkpointHook.handleCheckpointWithCallData(caller, selector, msg.data);
+            } else {
+                result = checkpointHook.handleCheckpointWithRef(caller, selector, ref);
+            }
             if (result == HookResult.ForceActivation) return (ref, true);
             if (result == HookResult.ForceDeactivation) return (ref, false);
+            if (result == HookResult.Block) revert CheckpointBlockedByHook();
             // Otherwise, just keep on with default checkpoint configuration and logic.
         }
         if (checkpoint.activation == Activation.Inactive) return (ref, false);

--- a/src/interfaces/Activation.sol
+++ b/src/interfaces/Activation.sol
@@ -14,5 +14,7 @@ enum Activation {
     /// @notice Security checks are only required if a specific function argument exceeds the threshold.
     ConstantThreshold,
     /// @notice For adding up all intercepted values by the same checkpoint before comparing with the threshold.
-    AccumulatedThreshold
+    AccumulatedThreshold,
+    /// @notice For setting up hook controlled checkpoints.
+    HookControlled
 }

--- a/src/interfaces/ICheckpointHook.sol
+++ b/src/interfaces/ICheckpointHook.sol
@@ -10,7 +10,8 @@ pragma solidity ^0.8.25;
 enum HookResult {
     Inconclusive,
     ForceActivation,
-    ForceDeactivation
+    ForceDeactivation,
+    Block
 }
 
 /**
@@ -39,4 +40,11 @@ interface ICheckpointHook {
      * function can help add custom reasoning.
      */
     function handleCheckpointWithRef(address caller, bytes4 selector, uint256 ref) external view returns (HookResult);
+    /**
+     * @notice Called by a firewall when the address is configured in settings and the checkpoint
+     * is based on a hash of the call data.
+     * @param caller The caller observed and reported by the firewall.
+     * @param selector The function selector which the checkpoint is configured for.
+     */
+    function handleCheckpointWithCallData(address caller, bytes4 selector, bytes calldata data) external view returns (HookResult);
 }

--- a/src/interfaces/ICheckpointHook.sol
+++ b/src/interfaces/ICheckpointHook.sol
@@ -42,9 +42,10 @@ interface ICheckpointHook {
     function handleCheckpointWithRef(address caller, bytes4 selector, uint256 ref) external view returns (HookResult);
     /**
      * @notice Called by a firewall when the address is configured in settings and the checkpoint
-     * is based on a hash of the call data.
+     * is a hook controlled one.
      * @param caller The caller observed and reported by the firewall.
      * @param selector The function selector which the checkpoint is configured for.
+     * @param data Intercepted call data.
      */
     function handleCheckpointWithCallData(address caller, bytes4 selector, bytes calldata data) external view returns (HookResult);
 }


### PR DESCRIPTION
- New checkpoint activation type `HookControlled`
- New hook result type `Block` (causes a revert)
- New hook function `handleCheckpointWithCallData()` for hook controlled checkpoints, which receives the full call data as the third argument

This allows creating hook contracts which can allow or refuse protected contract calls based on the call data. The ability to fallback to checkpoint execution is still preserved.